### PR TITLE
Piwik call protocol in config value

### DIFF
--- a/app/views/layouts/_piwik.html.haml
+++ b/app/views/layouts/_piwik.html.haml
@@ -4,7 +4,7 @@
   _paq.push(["enableLinkTracking"]);
 
   (function() {
-    var u=(("https:" == document.location.protocol) ? "https" : "http") + "://#{extra_config.piwik_url}/";
+    var u="#{extra_config.piwik_url}/";
     _paq.push(["setTrackerUrl", u+"piwik.php"]);
     _paq.push(["setSiteId", "#{extra_config.piwik_site_id}"]);
     var d=document, g=d.createElement("script"), s=d.getElementsByTagName("script")[0]; g.type="text/javascript";


### PR DESCRIPTION
When having a full url with protocol in the gitlab.yml file the javascript injected wont work.

This fix will make the config file values like:

```
piwik_url: "https://piwiklocation.com/piwik"
piwik_site_id: "7"
```
